### PR TITLE
Remove Codecov Bash script patch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,11 +34,10 @@ build_script:
 test_script:
 - cmd: test.cmd
 - sh: ./test.sh
-- sh: # revert to following post merge of PR codecov/codecov-bash#138
-- sh: # curl -sSL https://codecov.io/bash > codecov
-- sh: curl -sSL https://raw.githubusercontent.com/codecov/codecov-bash/14662d32a4862918c31efafe4b450de1305a38e1/codecov > codecov
-- sh: chmod +x codecov
-- sh: ./codecov -f ./tests/coverage.opencover.xml
+- sh: |-
+    curl -sSL https://codecov.io/bash > codecov
+    chmod +x codecov
+    ./codecov -f ./tests/coverage.opencover.xml
 artifacts:
 - path: dist\*.nupkg
 deploy:


### PR DESCRIPTION
This PR removes the patch that was needed until merge of codecov/codecov-bash#138.