### PR TITLE
Fix (CI) path to coverage report

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ test_script:
 - sh: # curl -sSL https://codecov.io/bash > codecov
 - sh: curl -sSL https://raw.githubusercontent.com/codecov/codecov-bash/14662d32a4862918c31efafe4b450de1305a38e1/codecov > codecov
 - sh: chmod +x codecov
-- sh: ./codecov -f ./tests/coverage.opencover.xml
+- sh: ./codecov -f ./tests/Tests/coverage.opencover.xml
 artifacts:
 - path: dist\*.nupkg
 deploy:


### PR DESCRIPTION
Codecov script to publish the coverage report during CI has been complaining since some time that:

    ==> Reading reports
        - file not found at ./tests/coverage.opencover.xml

The problem may have been introduced with commit "[Test against a real external program](https://github.com/atifaziz/Spawnr/commit/be56bf5f0ba5ca63deab80d5f974db5ce4d32ab1)" (be56bf5f0ba5ca63deab80d5f974db5ce4d32ab1) when the unit tests were moved to a subfolder to make space for the test app.

This PR fixes the path to the coverage report.
